### PR TITLE
Pin urllib3 to versions including allowed_methods

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-Multipass-CERN
-version = 2.2
+version = 2.2.1
 description = CERN-specific Flask-Multipass providers
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
@@ -16,6 +16,7 @@ py_modules =
     flask_multipass_cern
 install_requires =
     flask-multipass[authlib]>=0.4.3
+    urllib3>=1.26.0
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Given the [retry configuration](https://github.com/indico/flask-multipass-cern/blob/master/flask_multipass_cern.py#L34) uses `allowed_methods`, @ThiefMaster suggested it is a good idea to pin urllib3 to versions [>=1.26.0](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1260-2020-11-10).