### PR TITLE
Add retry delay

### DIFF
--- a/flask_multipass_cern.py
+++ b/flask_multipass_cern.py
@@ -30,6 +30,7 @@ CERN_OIDC_WELLKNOWN_URL = 'https://auth.cern.ch/auth/realms/cern/.well-known/ope
 HTTP_RETRY_COUNT = 5
 
 retry_config = HTTPAdapter(max_retries=Retry(total=HTTP_RETRY_COUNT,
+                                             backoff_factor=0.5,
                                              status_forcelist=[503, 504],
                                              allowed_methods=frozenset(['GET']),
                                              raise_on_status=False))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-Multipass-CERN
-version = 2.2.2
+version = 2.2.3
 description = CERN-specific Flask-Multipass providers
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM


### PR DESCRIPTION
This PR adds a backoff factor to retries: the first retry is instantaneous, but subsequent retries have a 0.5, 1, 2 and 4 seconds delay.