### PR TITLE
Escape slashes in identifier for API requests

### DIFF
--- a/flask_multipass_cern.py
+++ b/flask_multipass_cern.py
@@ -378,6 +378,7 @@ class CERNIdentityProvider(IdentityProvider):
 
     def get_identity_groups(self, identifier):
         with self._get_api_session() as api_session:
+            identifier = identifier.replace('/', '%2F')  # edugain identifiers sometimes contain slashes
             resp = api_session.get(f'{self.authz_api_base}/api/v1.0/IdentityMembership/{identifier}/precomputed')
             if resp.status_code == 404 or resp.status_code == 500:
                 return set()
@@ -503,6 +504,7 @@ class CERNIdentityProvider(IdentityProvider):
             ]
         }
         with self._get_api_session() as api_session:
+            identifier = identifier.replace('/', '%2F')  # edugain identifiers sometimes contain slashes
             resp = api_session.get(f'{self.authz_api_base}/api/v1.0/Identity/{identifier}', params=params)
             resp.raise_for_status()
             data = resp.json()

--- a/tests/test_request_retry.py
+++ b/tests/test_request_retry.py
@@ -12,7 +12,7 @@ def test_get_identity_groups_retry(provider):
     httpretty.register_uri(httpretty.GET, test_uri, status=503)
 
     try:
-        provider.get_identity_groups(1)
+        provider.get_identity_groups('1')
     except requests.exceptions.RequestException:
         assert len(httpretty.latest_requests()) == HTTP_RETRY_COUNT + 1
 
@@ -24,7 +24,7 @@ def test_get_identity_data_retry(provider):
     httpretty.register_uri(httpretty.GET, test_uri, status=503)
 
     try:
-        provider._get_identity_data(1)
+        provider._get_identity_data('1')
     except requests.exceptions.RequestException:
         assert len(httpretty.latest_requests()) == HTTP_RETRY_COUNT + 1
 


### PR DESCRIPTION
Not sure if we need it for the group membership check as well...
Edit: Yes we do, it was 404ing (which we silently ignore) for that call.