### PR TITLE
Fix KeyError when fields are missing in token

### DIFF
--- a/flask_multipass_cern.py
+++ b/flask_multipass_cern.py
@@ -269,12 +269,12 @@ class CERNIdentityProvider(IdentityProvider):
                 raise IdentityRetrievalFailed('Retrieving identity information from CERN SSO failed', provider=self)
 
             data = {
-                'firstName': auth_info.data['given_name'],
-                'lastName': auth_info.data['family_name'],
-                'displayName': auth_info.data['name'],
+                'firstName': auth_info.data.get('given_name'),
+                'lastName': auth_info.data.get('family_name'),
+                'displayName': auth_info.data.get('name'),
                 'telephone1': phone,
                 'instituteName': affiliation,
-                'primaryAccountEmail': auth_info.data['email'],
+                'primaryAccountEmail': auth_info.data.get('email'),
             }
 
         self._fix_phone(data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-Multipass-CERN
-version = 2.2.4
+version = 2.2.5
 description = CERN-specific Flask-Multipass providers
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM

--- a/tests/test_request_retry.py
+++ b/tests/test_request_retry.py
@@ -5,6 +5,11 @@ import requests
 from flask_multipass_cern import HTTP_RETRY_COUNT
 
 
+@pytest.fixture(autouse=True)
+def faster_retries(monkeypatch):
+    monkeypatch.setattr('flask_multipass_cern.retry_config.max_retries.backoff_factor', 0)
+
+
 @pytest.mark.usefixtures('httpretty_enabled', 'mock_get_api_session')
 def test_get_identity_groups_retry(provider):
     authz_api = provider.settings.get('authz_api')


### PR DESCRIPTION
The API does not send fields which are empty, so `get_identity_from_auth` was raising `KeyError` when the expected keys weren't there.

This PR fixes that.