### PR TITLE
Don't cache failed group membership queries

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,4 @@
 [flake8]
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
-
 max-line-length = 120
 
 inline-quotes = single

--- a/flask_multipass_cern.py
+++ b/flask_multipass_cern.py
@@ -153,9 +153,9 @@ class CERNGroup(Group):
                     'primaryAccountEmail',
                     'personId',
                 ],
-                'recursive': 'true'
             }
-            results = self.provider._fetch_all(api_session, f'/api/v1.0/Group/{gid}/memberidentities', params)[0]
+            results = self.provider._fetch_all(api_session, f'/api/v1.0/Group/{gid}/memberidentities/precomputed',
+                                               params)[0]
         for res in results:
             del res['id']  # id is always included
             self.provider._fix_phone(res)

--- a/flask_multipass_cern.py
+++ b/flask_multipass_cern.py
@@ -383,7 +383,7 @@ class CERNIdentityProvider(IdentityProvider):
         with self._get_api_session() as api_session:
             identifier = identifier.replace('/', '%2F')  # edugain identifiers sometimes contain slashes
             resp = api_session.get(f'{self.authz_api_base}/api/v1.0/IdentityMembership/{identifier}/precomputed')
-            if resp.status_code == 404 or resp.status_code == 500:
+            if resp.status_code == 404:
                 return set()
             resp.raise_for_status()
             results = resp.json()['data']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Flask-Multipass-CERN
-version = 2.2.7
+version = 2.2.8
 description = CERN-specific Flask-Multipass providers
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ install_requires =
 [options.extras_require]
 dev =
   flake8
-  flake8-colors
   flake8-quotes
   httpretty
   isort

--- a/tests/test_has_member.py
+++ b/tests/test_has_member.py
@@ -42,8 +42,8 @@ def test_has_member_cache(provider):
     test_group = CERNGroup(provider, 'cern users')
     test_group.has_member('12345')
 
-    assert(test_group.provider.cache.get('flask-multipass-cern:cip:groups:12345'))
-    assert(test_group.provider.cache.get('flask-multipass-cern:cip:groups:12345:timestamp'))
+    assert test_group.provider.cache.get('flask-multipass-cern:cip:groups:12345')
+    assert test_group.provider.cache.get('flask-multipass-cern:cip:groups:12345:timestamp')
 
 
 @pytest.mark.usefixtures('mock_get_identity_groups')

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ extras = dev
 skip_install = true
 deps =
     flake8
-    flake8-colors
     flake8-quotes
     isort
 commands =


### PR DESCRIPTION
Also use precomputed data when getting group membership list