### PR TITLE
ci: Add Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,8 @@ jobs:
           - { name: '3.10', python: '3.10', tox: py310 }
           - { name: '3.11', python: '3.11', tox: py311 }
           - { name: '3.12', python: '3.12', tox: py312 }
-          - { name: Style, python: '3.11', tox: style }
+          - { name: '3.13', python: '3.13', tox: py313 }
+          - { name: Style, python: '3.13', tox: style }
 
     steps:
       - uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py310
     py311
     py312
+    py313
     style
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Just adding it since I noticed we currently run style checks against 3.11 instead of 3.12...